### PR TITLE
Remove `promisify-node`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+dist: trusty
+sudo: required
+language: node_js
+node_js:
+  - "8"
+
+install:
+  - npm install
+
+script:
+  - npm test

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var IPFSHost = require("./lib/hosts/ipfshost");
 var IPFSHostWithLocalReader = require("./lib/hosts/ipfshostwithlocalreader");
 var MemoryRegistry = require("./lib/registries/memoryregistry");
 var Config = require("./lib/config");
-var promisify = require("promisify-node");
-var fs = promisify(require("fs-extra"));
+
+var fs = require('fs-extra');
 var path = require("path");
 var _ = require("lodash");
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,5 +1,4 @@
-var promisify = require("promisify-node");
-var fs = promisify(require("fs-extra"));
+var fs = require('fs-extra');
 var path = require("path");
 var Manifest = require("./manifest");
 var Lockfile = require("./lockfile");

--- a/lib/publisher.js
+++ b/lib/publisher.js
@@ -1,9 +1,8 @@
+var fs = require('fs-extra');
 var Manifest = require("./manifest");
 var Lockfile = require("./lockfile");
 var Sources = require("./sources");
 var path = require("path");
-var promisify = require("promisify-node");
-var fs = promisify(require("fs-extra"));
 
 function Publisher(registry, host, contract_types, deployments) {
   this.registry = registry;

--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
   "dependencies": {
     "async": "^2.1.2",
     "ethpm-spec": "^1.0.1",
-    "fs-extra": "^1.0.0",
+    "fs-extra": "^6.0.1",
     "glob": "^7.1.1",
     "ipfs-mini": "^1.1.2",
     "jsonschema": "^1.1.1",
     "lodash": "^4.17.1",
     "node-dir": "^0.1.16",
-    "promisify-node": "^0.4.0",
     "semver": "^5.3.0",
     "wget-improved": "^1.4.0"
   }

--- a/test/lib/testhelper.js
+++ b/test/lib/testhelper.js
@@ -4,9 +4,9 @@ var Config = require("../../lib/config");
 var IPFSHost = require("../../lib/hosts/ipfshost");
 var MemoryRegistry = require("../../lib/registries/memoryregistry");
 var Manifest = require("../../lib/manifest.js");
+
+var fs = require('fs-extra');
 var path = require("path");
-var promisify = require("promisify-node");
-var fs = promisify(require("fs-extra"));
 var solc = require("solc");
 var dir = require("node-dir");
 var each = require("async/each");

--- a/test/test_dependency_conflict.js
+++ b/test/test_dependency_conflict.js
@@ -28,7 +28,7 @@ describe("Dependency Conflict", function() {
   });
 
   before("published conflicting dependencies", function() {
-    this.timeout(10000);
+    this.timeout(25000);
 
     return owned1.package.publish().then(function() {
       return owned2.package.publish();
@@ -41,6 +41,8 @@ describe("Dependency Conflict", function() {
   });
 
   it("installs should fail during installation due to conflicting dependencies", function(done) {
+    this.timeout(25000);
+
     conflict.package.install().then(function() {
       return done(new Error("This error shouldn't be evaluated because another error should have come before it."));
     }).catch(function(e) {

--- a/test/test_install.js
+++ b/test/test_install.js
@@ -25,12 +25,14 @@ describe("Install", function() {
   });
 
   before("published owned for use as a dependency", function() {
-    this.timeout(10000);
+    this.timeout(25000);
 
     return owned.package.publish(owned.contract_metadata);
   });
 
   it("installs eth-usd correctly with owned as a dependency", function() {
+    this.timeout(25000);
+
     var dependency_path = path.resolve(path.join(eth_usd.package.config.installed_packages_directory, "owned"));
 
     return eth_usd.package.install().then(function() {

--- a/test/test_publish.js
+++ b/test/test_publish.js
@@ -27,7 +27,7 @@ describe("Publishing", function() {
   });
 
   it("published the correct lockfile, manifest file and source files", function() {
-    this.timeout(10000);
+    this.timeout(25000);
 
     var lockfile;
 
@@ -59,7 +59,7 @@ describe("Publishing", function() {
   });
 
   it("recognizes x-* options in the manifest and includes them in lockfile", function() {
-    this.timeout(10000);
+    this.timeout(25000);
 
     var lockfile;
 
@@ -77,6 +77,8 @@ describe("Publishing", function() {
   });
 
   it("correctly publishes packages with dependencies", function(){
+    this.timeout(25000);
+
     // First install any dependencies.
     return eth_usd.package.install().then(function() {
       return Sources.findDirectories(eth_usd.package.config.installed_packages_directory);


### PR DESCRIPTION
Node 10 is crashing on the promisification of `fs-extra` here (see [truffle 985](https://github.com/trufflesuite/truffle/issues/985).)  This is no longer necessary - newer [fs-extra](https://www.npmjs.com/package/fs-extra) has built-in promise support.

+ Also adds CI 